### PR TITLE
Prevent player from firing bullet while game is inactive

### DIFF
--- a/chapter_14/scoring/alien_invasion.py
+++ b/chapter_14/scoring/alien_invasion.py
@@ -91,14 +91,18 @@ class AlienInvasion:
 
     def _check_keydown_events(self, event):
         """Respond to keypresses."""
-        if event.key == pygame.K_RIGHT:
-            self.ship.moving_right = True
-        elif event.key == pygame.K_LEFT:
-            self.ship.moving_left = True
-        elif event.key == pygame.K_q:
+        # Keys that should be processed even while the game is inactive:
+        if event.key == pygame.K_q:
             sys.exit()
-        elif event.key == pygame.K_SPACE:
-            self._fire_bullet()
+            
+        # Keys that only make sense to process while the game is active:
+        if self.stats.game_active:
+            if event.key == pygame.K_RIGHT:
+                self.ship.moving_right = True
+            elif event.key == pygame.K_LEFT:
+                self.ship.moving_left = True
+            elif event.key == pygame.K_SPACE:
+                self._fire_bullet()
 
     def _check_keyup_events(self, event):
         """Respond to key releases."""


### PR DESCRIPTION
Addresses issue #7 .

Also refactored so that left and right are not processed while game is inactive.  Doesn't impact the gameplay currently, but could impact it as features get added.