### PR TITLE
fixed an issue for new versions of Django in the settings.py file

### DIFF
--- a/chapter_20/deploying_learning_log/learning_log/settings.py
+++ b/chapter_20/deploying_learning_log/learning_log/settings.py
@@ -62,7 +62,7 @@ ROOT_URLCONF = 'learning_log.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'DIRS': ['templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
On your website at https://ehmatthes.github.io/pcc_2e/updates/fifth_printing/, you recommended just adding a new import line to fix the issue but according to a Stack Overflow post at https://stackoverflow.com/questions/43287860/dirs-os-path-joinbase-dir-myfolder-templates-nameerror-name-os, I saw an easier way to get to the templates, which also seemingly is more efficient since it doesn't clog the call stack with a ton of subroutines, it seems to work fine for me but take another look at it just incase I got something wrong

its also likely the same issue is in other versions of settings.py